### PR TITLE
Add xmlstarlet to Working examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Here are some repos that use cibuildwheel.
 - [pikepdf](https://github.com/pikepdf/pikepdf)
 - [fathon](https://github.com/stfbnc/fathon)
 - [etebase-py](https://github.com/etesync/etebase-py) - Python bindings to a Rust library using `setuptools-rust`, and `sccache` for improved speed, built on Travis CI.
-
+- [xmlstarlet](https://github.com/dimitern/xmlstarlet) - Python CFFI bindings to XMLStarlet XML processing CLI.
 > Add your repo here! Send a PR.
 >
 > <sup>I'd like to include notes here to indicate why an example might be interesting to cibuildwheel users - the styles/technologies/techniques used in each. Please include that in future additions!</sup>


### PR DESCRIPTION
Hey @joerick!

First, thank you for the amazing project! I'd like to suggest adding my package to the examples, which uses `cibuildwheel` with GitHub Actions to build binary wheels for Python 3.6+ and Linux, MacOS, and Windows.

Some notes:
 - The easiest way to install and use the tool on Windows (from Python), also builds a truly native MSVC win_amd64 binary (not MinGW64).
 - I couldn't find a good example of a usable CFFI cross-platform binary wheel build setup (esp. when the original C sources only build under MinGW32).
 - I hope it's useful to somebody having difficulty with native Windows wheel builds. 

Cheers,
Dimiter